### PR TITLE
Disconnect from channel

### DIFF
--- a/mediasoup-client-ios/include/MediasoupDevice.h
+++ b/mediasoup-client-ios/include/MediasoupDevice.h
@@ -15,16 +15,8 @@
 #define MediasoupDevice_h
 
 @interface MediasoupDevice : NSObject
-/*! @brief libmediasoupclient native device object */
-@property(nonatomic, strong) NSValue* _nativeDevice;
-
-/*!
-    @brief Creates a new libmediasoupclient device object
-    @return New libmediasoupclient device object
- */
 -(id)init;
-/*! @brief Destroys the libmediasoupclient device */
--(void)dispose;
+
 /*!
     @brief Loads the device with the RTP capabilities of the mediasoup router
     @discussion This method takes the RTP capabilities of the mediasoup router and works out what media codecs to use etc.

--- a/mediasoup-client-ios/include/RecvTransport.h
+++ b/mediasoup-client-ios/include/RecvTransport.h
@@ -17,8 +17,6 @@
 /*! @brief libmediasoupclient native recv transport object */
 @property(nonatomic, strong) NSValue* _nativeTransport;
 
-/*! @brief Disposes of the recv transport instance */
--(void)dispose;
 /*!
     @brief Instructs the transport to receive an audio or video track to the mediasoup router
     @param listener ConsumerListener deletage

--- a/mediasoup-client-ios/include/SendTransport.h
+++ b/mediasoup-client-ios/include/SendTransport.h
@@ -18,8 +18,6 @@
 /*! @brief libmediasoupclient native send transport object */
 @property(nonatomic, strong) NSValue* _nativeTransport;
 
-/*! @brief Disposes of the send transport instance */
--(void)dispose;
 /*!
     @brief Instructs the transport to send an audio or video track to the mediasoup router
     @param listener ProducerListener delegate

--- a/mediasoup-client-ios/src/C++Wrapper/TransportWrapper.mm
+++ b/mediasoup-client-ios/src/C++Wrapper/TransportWrapper.mm
@@ -110,7 +110,6 @@ using namespace mediasoupclient;
     MSC_TRACE();
     
     [TransportWrapper extractNativeTransport:nativeTransport]->Close();
-    [nativeTransport release];
 }
 
 +(NSValue *)nativeGetNativeTransport:(NSValue *)nativeTransport {

--- a/mediasoup-client-ios/src/MediasoupDevice.mm
+++ b/mediasoup-client-ios/src/MediasoupDevice.mm
@@ -9,44 +9,56 @@
 #import "MediasoupDevice.h"
 #import "DeviceWrapper.h"
 
+@interface MediasoupDevice()
+@property(nonatomic, retain) NSValue *nativeDevice;
+@end
+
 @implementation MediasoupDevice : NSObject
 
 -(instancetype)init {
     self = [super init];
     if (self) {
-        self._nativeDevice = [DeviceWrapper nativeNewDevice];
+        self.nativeDevice = [DeviceWrapper nativeNewDevice];
     }
     
     return self;
 }
 
+-(void)dealloc {
+    if (self.nativeDevice != nil) {
+        [DeviceWrapper nativeFreeDevice: self.nativeDevice];
+    }
+    self.nativeDevice = nil;
+    [super dealloc];
+}
+
 -(void)load:(NSString *)routerRtpCapabilities {
     [self checkDeviceExists];
-    [DeviceWrapper nativeLoad:self._nativeDevice routerRtpCapabilities:routerRtpCapabilities];
+    [DeviceWrapper nativeLoad:self.nativeDevice routerRtpCapabilities:routerRtpCapabilities];
 }
 
 -(bool)isLoaded {
     [self checkDeviceExists];
     
-    return [DeviceWrapper nativeIsLoaded:self._nativeDevice];
+    return [DeviceWrapper nativeIsLoaded:self.nativeDevice];
 }
 
 -(NSString *)getRtpCapabilities {
     [self checkDeviceExists];
     
-    return [DeviceWrapper nativeGetRtpCapabilities:self._nativeDevice];
+    return [DeviceWrapper nativeGetRtpCapabilities:self.nativeDevice];
 }
 
 -(NSString *)getSctpCapabilities {
     [self checkDeviceExists];
     
-    return [DeviceWrapper nativeGetSctpCapabilities:self._nativeDevice];
+    return [DeviceWrapper nativeGetSctpCapabilities:self.nativeDevice];
 }
 
 -(bool)canProduce:(NSString *)kind {
     [self checkDeviceExists];
     
-    return [DeviceWrapper nativeCanProduce:self._nativeDevice kind:kind];
+    return [DeviceWrapper nativeCanProduce:self.nativeDevice kind:kind];
 }
 
 -(SendTransport *)createSendTransport:(id<SendTransportListener>)listener id:(NSString *)id iceParameters:(NSString *)iceParameters iceCandidates:(NSString *)iceCandidates dtlsParameters:(NSString *)dtlsParameters {
@@ -56,7 +68,7 @@
 -(SendTransport *)createSendTransport:(id<SendTransportListener>)listener id:(NSString *)id iceParameters:(NSString *)iceParameters iceCandidates:(NSString *)iceCandidates dtlsParameters:(NSString *)dtlsParameters sctpParameters:(NSString *)sctpParameters options:(RTCPeerConnectionFactoryOptions *)options appData:(NSString *)appData {
     [self checkDeviceExists];
     
-    NSObject *transport = [DeviceWrapper nativeCreateSendTransport:self._nativeDevice listener:listener id:id iceParameters:iceParameters iceCandidates:iceCandidates dtlsParameters:dtlsParameters sctpParameters:sctpParameters options:options appData:appData];
+    NSObject *transport = [DeviceWrapper nativeCreateSendTransport:self.nativeDevice listener:listener id:id iceParameters:iceParameters iceCandidates:iceCandidates dtlsParameters:dtlsParameters sctpParameters:sctpParameters options:options appData:appData];
     
     return [[SendTransport alloc] initWithNativeTransport:transport];
 }
@@ -68,13 +80,13 @@
 -(RecvTransport *)createRecvTransport:(id<RecvTransportListener>)listener id:(NSString *)id iceParameters:(NSString *)iceParameters iceCandidates:(NSString *)iceCandidates dtlsParameters:(NSString *)dtlsParameters sctpParameters:(NSString *)sctpParameters options:(RTCPeerConnectionFactoryOptions *)options appData:(NSString *)appData {
     [self checkDeviceExists];
     
-    NSObject *transport = [DeviceWrapper nativeCreateRecvTransport:self._nativeDevice listener:listener id:id iceParameters:iceParameters iceCandidates:iceCandidates dtlsParameters:dtlsParameters sctpParameters:sctpParameters options:options appData:appData];
+    NSObject *transport = [DeviceWrapper nativeCreateRecvTransport:self.nativeDevice listener:listener id:id iceParameters:iceParameters iceCandidates:iceCandidates dtlsParameters:dtlsParameters sctpParameters:sctpParameters options:options appData:appData];
     
     return [[RecvTransport alloc] initWithNativeTransport:transport];
 }
 
 -(void)checkDeviceExists {
-    if (self._nativeDevice == nil) {
+    if (self.nativeDevice == nil) {
         NSException* exception = [NSException exceptionWithName:@"IllegalStateException" reason:@"Device has been disposed." userInfo:nil];
         
         throw exception;

--- a/mediasoup-client-ios/src/RecvTransport.mm
+++ b/mediasoup-client-ios/src/RecvTransport.mm
@@ -22,12 +22,6 @@
     return self;
 }
 
--(void)dispose {
-    [self checkTransportExists];
-    
-    [TransportWrapper nativeFreeTransport:self._nativeTransport];
-}
-
 -(Consumer *)consume:(id<ConsumerListener>)listener id:(NSString *)id producerId:(NSString *)producerId kind:(NSString *)kind rtpParameters:(NSString *)rtpParameters {
     return [self consume:listener id:id producerId:producerId kind:kind rtpParameters:rtpParameters appData:nil];
 }

--- a/mediasoup-client-ios/src/SendTransport.mm
+++ b/mediasoup-client-ios/src/SendTransport.mm
@@ -22,12 +22,6 @@
     return self;
 }
 
--(void)dispose {
-    [self checkTransportExists];
-    
-    [TransportWrapper nativeFreeTransport:self._nativeTransport];
-}
-
 -(Producer *)produce:(id<ProducerListener>)listener track:(RTCMediaStreamTrack *)track encodings:(NSArray *)encodings codecOptions:(NSString *)codecOptions {
     return [self produce:listener track:track encodings:encodings codecOptions:codecOptions appData:nil];
 }


### PR DESCRIPTION
This patch fixes the crash during an attempt to disconnect from a channel.

Related issues:
* https://github.com/ethand91/mediasoup-ios-client/issues/92
* https://github.com/ethand91/mediasoup-ios-client/issues/55

Currently I'm working on the memory leaks that are still there, but they are a bit harder to verify than the crash itself.